### PR TITLE
Run the snapshot tests on multiple node versions

### DIFF
--- a/.github/workflows/snapshot-tests.yml
+++ b/.github/workflows/snapshot-tests.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: ['14', '16', '18']
     steps:
       - uses: actions/checkout@v3
-      - run: ./tests/snapshot/scripts/run-docker-tests.sh
+      - run: ./tests/snapshot/scripts/run-docker-tests.sh ${{ matrix.node-version }}

--- a/tests/snapshot/scripts/install-package.sh
+++ b/tests/snapshot/scripts/install-package.sh
@@ -13,7 +13,9 @@ cp package.json ./dist/
 cp .npmignore ./dist/
 
 echo "Building package"
-(cd dist && npm pack --pack-destination ../)
+(cd dist && npm pack)
+
+mv dist/data-bakery-*.tgz ./
 
 BUILT_PACK_PATH=$(realpath data-bakery-*.tgz)
 echo "FOUND PACKAGE: ${BUILT_PACK_PATH}"

--- a/tests/snapshot/scripts/run-docker-tests.sh
+++ b/tests/snapshot/scripts/run-docker-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+NODE_VERSION="$1"
 BASE_DIR=$(pwd)
 
-docker run -v "${BASE_DIR}":/code --entrypoint /code/tests/snapshot/scripts/docker-entrypoint.sh node:18-buster-slim
+docker run -v "${BASE_DIR}":/code --entrypoint /code/tests/snapshot/scripts/docker-entrypoint.sh "node:${NODE_VERSION}-buster-slim"


### PR DESCRIPTION
Test the snapshots on Node v14, 16, and 18 instead of just 18.