### PR TITLE
Add RecipeManager to recipe context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Next
+
+- Add `manager` to recipe context
+    - This is an instance of `RecipeManager`, to enable more powerful `getNamedId` usages
+- Add `RecipeManager.getNamedId` function to allow accessing Named ID values outside of simple column values
+    - For example, using the ID value to generate part of a string
+
 ## 1.0.3
 
 - Improve the docs in `README.md` to include config and all of the core features

--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ By default, all function recipes are provided a recipe context like this:
 
 ```ts
 {
-  sqlDialect: 'mysql'
+  sqlDialect: 'mysql',
+  manager: RecipeManager,
 }
 ```
 
@@ -229,6 +230,24 @@ module.exports = {
     },
   ],
 }
+```
+
+If you want to access the named ID outside of a simple column value use case, you should export your recipe as a function and use `manager.getNamedId()` instead.
+
+```ts
+module.exports = async ({ manager }) => ({
+  user: [
+    { id: new NamedId('firstUser'), email: 'hello@world.com' },
+  ],
+  user_extra: [
+    {
+      json: JSON.stringify({
+        // This will evaluate to `1-static-prefix` for example
+        generatedId: `${manager.getNamedId('user', 'firstUser')}-static-prefix`,
+      }),
+    },
+  ],
+})
 ```
 
 After running the `generate` command, a `meta.json` file will be created.

--- a/src/export-generator.ts
+++ b/src/export-generator.ts
@@ -54,6 +54,7 @@ export class ExportGenerator {
       const recipeContext = {
         ...this.#extraRecipeContext,
         sqlDialect: this.#sqlDialect,
+        manager: this.#recipeManager,
       }
       recipeBundle = await recipeExport(recipeContext)
     } else {

--- a/src/recipe-manager.ts
+++ b/src/recipe-manager.ts
@@ -85,6 +85,14 @@ export class RecipeManager {
   }
 
   /**
+   * Convenience function to access generated named IDs, such as from the context
+   * of a recipe file being processed.
+   */
+  getNamedId (tableName: TableName, idName: NamedIdName): number {
+    return this.#generateNamedIdForTable(tableName, idName, true)
+  }
+
+  /**
    * Generate and retrieve the generated ID value for a given named ID.
    */
   #generateNamedIdForTable (tableName: TableName, idName: NamedIdName, isPlaceholder: boolean = false): number {

--- a/tests/snapshot/tests/manager-get-named-id/data-bakery.config.js
+++ b/tests/snapshot/tests/manager-get-named-id/data-bakery.config.js
@@ -1,0 +1,6 @@
+module.exports = () => ({
+  recipesDir: 'recipes',
+  sqlDialect: 'mysql',
+  outputDir: 'actual-output',
+  emptyOutputDir: true,
+})

--- a/tests/snapshot/tests/manager-get-named-id/expected-output/example.sql
+++ b/tests/snapshot/tests/manager-get-named-id/expected-output/example.sql
@@ -1,0 +1,2 @@
+INSERT INTO `user` (id,email) VALUES (1, 'hello@world.com');
+INSERT INTO `user_extra` (id,json) VALUES (1, '{"generatedId":"1-static-prefix"}');

--- a/tests/snapshot/tests/manager-get-named-id/expected-output/meta.json
+++ b/tests/snapshot/tests/manager-get-named-id/expected-output/meta.json
@@ -1,0 +1,9 @@
+{
+  "namedIds": {
+    "user": {
+      "helloWorld": {
+        "id": 1
+      }
+    }
+  }
+}

--- a/tests/snapshot/tests/manager-get-named-id/recipes/example.js
+++ b/tests/snapshot/tests/manager-get-named-id/recipes/example.js
@@ -1,0 +1,15 @@
+const { NamedId, getNamedId } = require('data-bakery')
+
+module.exports = async ({ manager }) => ({
+  user: [
+    { id: new NamedId('helloWorld'), email: 'hello@world.com' },
+  ],
+  user_extra: [
+    {
+      id: getNamedId('user', 'helloWorld'),
+      json: JSON.stringify({
+        generatedId: `${manager.getNamedId('user', 'helloWorld')}-static-prefix`,
+      }),
+    },
+  ],
+})


### PR DESCRIPTION
Allow recipes to access the `RecipeManager` in order for more powerful interactions with named ID values.

For example, being able to use an ID value as part of a generated string.

This resolves #4.